### PR TITLE
FIX: 'rake -T' command Error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'sinatra/activerecord/rake'
 require_relative './config/environment'
+require 'sinatra/activerecord/rake'
 
 # Type `rake -T` on your command line to see the available rake tasks.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-ENV["SINATRA_ENV"] ||= "development"
-
 require 'sinatra/activerecord/rake'
 require_relative './config/environment'
 


### PR DESCRIPTION
A student had an issue with running the 'rake -T' command. With the way the file is currently coded, this error is given:

> LoadError: cannot load such file -- active_record/railties/databases.rake

Removing the environment setting statement `ENV["SINATRA_ENV"] ||= "development"` and just requiring the `environment.rb` file first, fixes this error.
